### PR TITLE
Add a default option when holding the screenshot button to skip the confirmation popup

### DIFF
--- a/app/src/main/java/com/github/cvzi/screenshottile/utils/PrefManager.kt
+++ b/app/src/main/java/com/github/cvzi/screenshottile/utils/PrefManager.kt
@@ -62,6 +62,13 @@ class PrefManager(private val context: Context, private val pref: SharedPreferen
             value
         ).apply()
 
+    var skipDelayConfirmation: Boolean
+        get() = pref.getBoolean(context.getString(R.string.pref_key_skip_delay_confirmation), true)
+        set(value) = pref.edit().putBoolean(
+            context.getString(R.string.pref_key_skip_delay_confirmation),
+            value
+        ).apply()
+
     var useNative: Boolean
         get() = pref.getBoolean(context.getString(R.string.pref_key_use_native), false)
         set(value) = pref.edit().putBoolean(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="setting_delay_entry_2s">2s</string>
     <string name="setting_delay_entry_5s">5s</string>
     <string name="show_count_down">Show count down</string>
+    <string name="skip_delay_confirmation">Skip delay confirmation</string>
     <string name="use_native_screenshot">Use native screenshot method</string>
     <string name="use_native_screenshot_summary">Simulate home + power button press</string>
     <string name="use_native_screenshot_unsupported">Requires Android 9 Pie</string>

--- a/app/src/main/res/values/strings_untranslatable.xml
+++ b/app/src/main/res/values/strings_untranslatable.xml
@@ -18,6 +18,7 @@
     </string-array>
     <string name="pref_key_delay" translatable="false">delays_string</string>
     <string name="pref_key_show_count_down" translatable="false">show_count_down</string>
+    <string name="pref_key_skip_delay_confirmation" translatable="false">skip_delay_confirmation</string>
     <string name="pref_key_use_native" translatable="false">use_native</string>
     <string name="pref_key_use_system_defaults" translatable="false">use_system_defaults</string>
     <string name="pref_key_hide_app" translatable="false">hide_app</string>

--- a/app/src/main/res/xml/pref.xml
+++ b/app/src/main/res/xml/pref.xml
@@ -14,6 +14,12 @@
         android:title="@string/show_count_down"
         app:iconSpaceReserved="false" />
 
+    <androidx.preference.SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_skip_delay_confirmation"
+        android:title="@string/skip_delay_confirmation"
+        app:iconSpaceReserved="false" />
+
     <androidx.preference.ListPreference
         android:defaultValue="@string/setting_delay_value_default"
         android:entries="@array/setting_delay_entries"


### PR DESCRIPTION
An attempt at adding a default action for holding the screenshot button in the quick access menu to skip the confirmation popup