### PR TITLE
Replace my own username in the mention

### DIFF
--- a/app/src/main/res/values/strings_untranslatable.xml
+++ b/app/src/main/res/values/strings_untranslatable.xml
@@ -301,7 +301,7 @@ Contribute on <a href="https://crwd.in/screenshottile">crwd.in/screenshottile</a
 &#127481;&#127479; provided by <a href="https://myanimelist.net/profile/kyoyatempest">kyoya</a> and <a href="https://github.com/erickyun">erickyun</a><br>
 <br>
 <br>
-Material You design contributed by <a href="https://github.com/user0-tb">user0-tb</a><br>
+Material You design contributed by <a href="https://github.com/user0-07161/">user0</a><br>
 
 ]]></string>
 


### PR DESCRIPTION
Since I've changed my username, the hyperlink wouldn't work anymore. This PR fixes that.