### PR TITLE
feat: add ScreenshotTriggerActivity for startActivity-only callers

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,28 +215,30 @@ adb shell am broadcast -a com.github.cvzi.screenshottile.SCREENSHOT -e secret MY
 
 # <a name="activity">Automatic screenshots with Activity intents</a>
 
-Some callers can only fire `startActivity` and cannot send a broadcast — for example hardware-key dispatchers like the Motorola AI Key / Red Key (`com.motorola.mykey`), button-mapper apps, or custom launchers. For these, `ScreenshotTriggerActivity` accepts the same secret-gated request as the broadcast above, via an activity intent.
+Some apps can only start an activity and cannot send a broadcast, for example the Motorola AI Key / Red Key (`com.motorola.mykey`), button remapper apps or custom launchers. For those you can use `ScreenshotTriggerActivity`, which takes the same `secret` and `partial` extras as the broadcast intent above.
 
-It uses the same screenshot path as the Quick Settings tile (no extra activity is launched and the foreground app's task is not disturbed), so the captured screenshot is of the app you were looking at.
+First you have to activate this feature by setting a password in the app settings (the same password as for the broadcast intent).
 
-First activate the feature by setting a password in the app settings (same password used for the broadcast intent).
-
-From a terminal / adb:
+You can take screenshots from the terminal:
 
 ```bash
 # Take a screenshot
-adb shell am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT --es secret MY_PASSWORD
+am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT -e secret MY_PASSWORD
 # Open the area selector for a partial screenshot
-adb shell am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT --es secret MY_PASSWORD --ez partial true
+am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT -e secret MY_PASSWORD --ez partial true
 ```
 
-As an intent URI (e.g. for an app that stores a launchable intent in a setting):
+Or via adb from a computer:
+
+```bash
+adb shell am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT -e secret MY_PASSWORD
+```
+
+Apps that store a launchable intent (like the Motorola AI Key settings) can use an intent URI:
 
 ```
 intent:#Intent;action=com.github.cvzi.screenshottile.TAKE_SCREENSHOT;launchFlags=0x10000000;S.secret=MY_PASSWORD;end
 ```
-
-The accepted extras match the broadcast intent: `secret` (required) and `partial` (optional, `true` to open the area selector).
 
 ## Miscellaneous data
 Some miscellaneous files (mostly images) that don't need to be in the main repository of ScreenshotTile were moved to a separate repository: https://github.com/cvzi/ScreenshotTile_miscellaneous

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Fork of [github.com/ipcjs/ScreenshotTile](https://github.com/ipcjs/ScreenshotTil
    - [Permission Scope](#permission-scope-only-legacy-method)
    - [Permissions](#permissions)
 - [Automatic screenshots](#automatic-screenshots-with-broadcast-intents)
+- [Screenshots via activity intent](#automatic-screenshots-with-activity-intents)
 - [Miscellaneous data](#miscellaneous-data)
 
 [Changelog](CHANGELOG.md) • [View older releases](https://gitlab.com/cvzi/binaries/-/tree/main/ScreenshotTile) • [Google store](https://play.google.com/store/apps/details?id=com.github.cvzi.screenshottile)
@@ -211,6 +212,31 @@ Or via [adb](https://developer.android.com/tools/adb) from a computer:
 ```bash
 adb shell am broadcast -a com.github.cvzi.screenshottile.SCREENSHOT -e secret MY_PASSWORD com.github.cvzi.screenshottile
 ```
+
+# <a name="activity">Automatic screenshots with Activity intents</a>
+
+Some callers can only fire `startActivity` and cannot send a broadcast — for example hardware-key dispatchers like the Motorola AI Key / Red Key (`com.motorola.mykey`), button-mapper apps, or custom launchers. For these, `ScreenshotTriggerActivity` accepts the same secret-gated request as the broadcast above, via an activity intent.
+
+It uses the same screenshot path as the Quick Settings tile (no extra activity is launched and the foreground app's task is not disturbed), so the captured screenshot is of the app you were looking at.
+
+First activate the feature by setting a password in the app settings (same password used for the broadcast intent).
+
+From a terminal / adb:
+
+```bash
+# Take a screenshot
+adb shell am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT --es secret MY_PASSWORD
+# Open the area selector for a partial screenshot
+adb shell am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT --es secret MY_PASSWORD --ez partial true
+```
+
+As an intent URI (e.g. for an app that stores a launchable intent in a setting):
+
+```
+intent:#Intent;action=com.github.cvzi.screenshottile.TAKE_SCREENSHOT;launchFlags=0x10000000;S.secret=MY_PASSWORD;end
+```
+
+The accepted extras match the broadcast intent: `secret` (required) and `partial` (optional, `true` to open the area selector).
 
 ## Miscellaneous data
 Some miscellaneous files (mostly images) that don't need to be in the main repository of ScreenshotTile were moved to a separate repository: https://github.com/cvzi/ScreenshotTile_miscellaneous

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,19 @@
             android:exported="false"
             android:theme="@android:style/Theme.NoDisplay" />
         <activity
+            android:name="com.github.cvzi.screenshottile.activities.ScreenshotTriggerActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:launchMode="standard"
+            android:noHistory="true"
+            android:taskAffinity=""
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="com.github.cvzi.screenshottile.TAKE_SCREENSHOT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="com.github.cvzi.screenshottile.activities.DelayScreenshotActivity"
             android:excludeFromRecents="true"
             android:exported="false" />

--- a/app/src/main/java/com/github/cvzi/screenshottile/activities/ScreenshotTriggerActivity.kt
+++ b/app/src/main/java/com/github/cvzi/screenshottile/activities/ScreenshotTriggerActivity.kt
@@ -8,30 +8,8 @@ import com.github.cvzi.screenshottile.R
 import com.github.cvzi.screenshottile.utils.setUserLanguage
 
 /**
- * Exported trampoline that lets callers which can only invoke [android.content.Context.startActivity]
- * (e.g. hardware-key dispatchers like Motorola MyKey, button-mapper apps, custom launchers)
- * trigger a screenshot.
- *
- * Mirrors:
- *  - the security model of [com.github.cvzi.screenshottile.IntentHandler] — gated by the
- *    user-configured broadcast secret stored in [com.github.cvzi.screenshottile.utils.PrefManager.broadcastSecret].
- *  - the screenshot code path of
- *    [com.github.cvzi.screenshottile.services.ScreenshotTileService.onClick] — directly calls
- *    [App.screenshot] / [App.screenshotPartial] without launching an inner activity, so the
- *    task stack of the originating foreground app is not disturbed.
- *
- * Intent action: `com.github.cvzi.screenshottile.TAKE_SCREENSHOT`
- *
- * Required string extra: `"secret"` — must match the secret configured in the app settings.
- * Optional extra:        `"partial"` (boolean or string `"true"`) — opens the area selector
- *                        instead of taking a full-screen screenshot.
- *
- * Example (from adb / a launcher / a hardware-key dispatcher):
- * ```
- * adb shell am start \
- *   -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT \
- *   --es secret yourPasswordFromAppSettings
- * ```
+ * Take a screenshot from apps that can only start an activity, like the Motorola AI Key.
+ * Uses the same secret and partial extras as [com.github.cvzi.screenshottile.IntentHandler].
  */
 class ScreenshotTriggerActivity : Activity() {
     /** Intent action and extra keys accepted by [ScreenshotTriggerActivity]. */

--- a/app/src/main/java/com/github/cvzi/screenshottile/activities/ScreenshotTriggerActivity.kt
+++ b/app/src/main/java/com/github/cvzi/screenshottile/activities/ScreenshotTriggerActivity.kt
@@ -1,0 +1,83 @@
+package com.github.cvzi.screenshottile.activities
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+import com.github.cvzi.screenshottile.App
+import com.github.cvzi.screenshottile.R
+import com.github.cvzi.screenshottile.utils.setUserLanguage
+
+/**
+ * Exported trampoline that lets callers which can only invoke [android.content.Context.startActivity]
+ * (e.g. hardware-key dispatchers like Motorola MyKey, button-mapper apps, custom launchers)
+ * trigger a screenshot.
+ *
+ * Mirrors:
+ *  - the security model of [com.github.cvzi.screenshottile.IntentHandler] — gated by the
+ *    user-configured broadcast secret stored in [com.github.cvzi.screenshottile.utils.PrefManager.broadcastSecret].
+ *  - the screenshot code path of
+ *    [com.github.cvzi.screenshottile.services.ScreenshotTileService.onClick] — directly calls
+ *    [App.screenshot] / [App.screenshotPartial] without launching an inner activity, so the
+ *    task stack of the originating foreground app is not disturbed.
+ *
+ * Intent action: `com.github.cvzi.screenshottile.TAKE_SCREENSHOT`
+ *
+ * Required string extra: `"secret"` — must match the secret configured in the app settings.
+ * Optional extra:        `"partial"` (boolean or string `"true"`) — opens the area selector
+ *                        instead of taking a full-screen screenshot.
+ *
+ * Example (from adb / a launcher / a hardware-key dispatcher):
+ * ```
+ * adb shell am start \
+ *   -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT \
+ *   --es secret yourPasswordFromAppSettings
+ * ```
+ */
+class ScreenshotTriggerActivity : Activity() {
+    companion object {
+        private const val TAG = "ScreenshotTriggerAct"
+        const val EXTRA_SECRET = "secret"
+        const val EXTRA_PARTIAL = "partial"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setUserLanguage()
+
+        if (!validateSecret()) {
+            finish()
+            return
+        }
+
+        val partial = intent.getBooleanExtra(EXTRA_PARTIAL, false) ||
+                intent.getStringExtra(EXTRA_PARTIAL)?.equals("true", ignoreCase = true) == true
+
+        if (partial) {
+            App.getInstance().screenshotPartial(this)
+        } else {
+            App.getInstance().screenshot(this)
+        }
+
+        finish()
+    }
+
+    private fun validateSecret(): Boolean {
+        val secret = intent.getStringExtra(EXTRA_SECRET)
+        val expected = App.getInstance().prefManager.broadcastSecret
+        val default = getString(R.string.setting_broadcast_secret_value_default)
+
+        if (secret.isNullOrEmpty()) {
+            Log.e(TAG, "Extra 'secret' is required.")
+            return false
+        }
+        if (expected.isEmpty() || expected == default) {
+            Log.e(TAG, "Secret was not set in the app settings.")
+            return false
+        }
+        if (expected != secret) {
+            Log.e(TAG, "Wrong secret.")
+            return false
+        }
+        return true
+    }
+}

--- a/app/src/main/java/com/github/cvzi/screenshottile/activities/ScreenshotTriggerActivity.kt
+++ b/app/src/main/java/com/github/cvzi/screenshottile/activities/ScreenshotTriggerActivity.kt
@@ -34,6 +34,7 @@ import com.github.cvzi.screenshottile.utils.setUserLanguage
  * ```
  */
 class ScreenshotTriggerActivity : Activity() {
+    /** Intent action and extra keys accepted by [ScreenshotTriggerActivity]. */
     companion object {
         private const val TAG = "ScreenshotTriggerAct"
         const val EXTRA_SECRET = "secret"


### PR DESCRIPTION
Issue - #764 


## Summary (AI Written)

Adds `ScreenshotTriggerActivity` — a small exported, secret-gated trampoline activity that lets callers which can only invoke `startActivity` trigger a screenshot. Mirrors `IntentHandler`'s security model (shared secret) and `ScreenshotTileService.onClick()`'s screenshot path (direct `App.screenshot()` call, no inner activity launch).

## Motivation

A class of callers can only fire `Context.startActivity(intent)` from their configuration — they cannot `sendBroadcast`. Examples:

- **Hardware-key dispatchers** like Motorola's MyKey (the "AI Key" / "Red Key" handler). Its `tap_app_quick_*` settings store an intent URI that the trigger service parses with `Intent.parseUri()` and launches via `startActivity` (or `LauncherApps.startShortcut` for the `SHORTCUT` action). There is no broadcast-dispatch path.
- **Button-mapper apps**, **custom launchers**, **assistant-key replacers** on devices that lack a dedicated assist gesture, etc.

For these, the existing static manifest shortcut (`takeScreenshot` → `NoDisplayActivity`) is the only `startActivity`-friendly entry — but Android auto-stamps manifest shortcuts with `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TASK | FLAG_ACTIVITY_TASK_ON_HOME` (`0x1000c000`). When invoked from a hardware-key dispatcher while another app is foregrounded, the `CLEAR_TASK + TASK_ON_HOME` combo causes a visible flash to the launcher *and the screenshot captures home instead of the originating app*. The shortcut was designed for app-icon long-press menus, not background-service dispatch.

The broadcast path (`IntentHandler`) doesn't have this issue (only adds `FLAG_ACTIVITY_NEW_TASK`), but is unreachable from callers that can't `sendBroadcast`.

## What this PR does

Adds one new activity + one manifest entry. ~80 LoC total.

### `ScreenshotTriggerActivity`

```kotlin
class ScreenshotTriggerActivity : Activity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setUserLanguage()
        if (!validateSecret()) { finish(); return }
        val partial = intent.getBooleanExtra(EXTRA_PARTIAL, false) ||
            intent.getStringExtra(EXTRA_PARTIAL)?.equals("true", true) == true
        if (partial) App.getInstance().screenshotPartial(this)
        else        App.getInstance().screenshot(this)
        finish()
    }
    // validateSecret(): same checks as IntentHandler
}
```

Manifest entry:

```xml
<activity
    android:name=".activities.ScreenshotTriggerActivity"
    android:exported="true"
    android:theme="@android:style/Theme.NoDisplay"
    android:excludeFromRecents="true"
    android:noHistory="true"
    android:taskAffinity=""
    android:launchMode="standard">
    <intent-filter>
        <action android:name="com.github.cvzi.screenshottile.TAKE_SCREENSHOT" />
        <category android:name="android.intent.category.DEFAULT" />
    </intent-filter>
</activity>
```

## Security model

Identical to the existing broadcast trigger (`IntentHandler`):

- **Caller must supply the `secret` extra**, matched against the `broadcastSecret` pref configured in app settings.
- The feature is opt-in: if the secret pref is unset or at its default `(unset)` value, every call is rejected with no action taken.
- Same `Log.e` warning lines as `IntentHandler` for failed validations.

Activity-level attributes make the trampoline transparent to the originating app's task stack:

- `Theme.NoDisplay` → no visible window opens
- `taskAffinity=""` → does not get absorbed into the caller's or any other app's task
- `noHistory="true"` + `excludeFromRecents="true"` → not retained anywhere
- `launchMode="standard"` (the default)

The activity does not declare or accept any other launch flags — it just acts on whatever flags the caller passes (typically `FLAG_ACTIVITY_NEW_TASK` when called from a background service context).

## Usage

```bash
# From a launcher / hardware-key dispatcher's config:
intent:#Intent;action=com.github.cvzi.screenshottile.TAKE_SCREENSHOT;launchFlags=0x10000000;S.secret=yourPasswordFromAppSettings;end

# Via adb (e.g. to confirm the flow works):
adb shell am start -a com.github.cvzi.screenshottile.TAKE_SCREENSHOT --es secret yourPasswordFromAppSettings
```

Optional `--ez partial true` to open the area selector instead of a full-screen capture, matching `IntentHandler`'s behavior.

## Test plan

Tested on Motorola Razr-class device, Android 16, ScreenshotTile installed with `Native method` + `Use system defaults` enabled and accessibility service granted. The MyKey app's double-press setting was set to:

```
intent:#Intent;action=com.github.cvzi.screenshottile.TAKE_SCREENSHOT;package=com.github.cvzi.screenshottile.debug;launchFlags=0x10000000;S.secret=mykeysecret;end
```

- ✅ Double-press from any foregrounded app → shutter sound, standard screenshot thumbnail, **saved screenshot is of the foregrounded app**
- ✅ No flash to launcher; foreground app remains visible throughout
- ✅ `partial=true` opens the area selector correctly
- ✅ Wrong secret → `Log.e("ScreenshotTriggerAct", "Wrong secret.")`, no screenshot
- ✅ Missing secret → `"Extra 'secret' is required."`, no screenshot
- ✅ Default/unset pref → `"Secret was not set in the app settings."`, no screenshot
- ✅ Existing entry points (QS tile, accessibility floating button, manifest shortcut, broadcast) unchanged

## Alternatives considered

- **Modify the static shortcut's flags** to drop `CLEAR_TASK | TASK_ON_HOME` — not possible for manifest shortcuts; Android applies those flags automatically when publishing. Would require switching to dynamic shortcuts, which is a much bigger change.
- **Make `NoDisplayActivity` itself exported** — would expand its responsibilities and existing internal callers' assumptions; the new activity is a cleaner separation of concerns.
- **Set the app as the device's voice assistant** (`MyVoiceInteractionService`) so callers can fire `ACTION_ASSIST` — works, but takes over long-press-home, the power-button assist menu, and every other assist gesture system-wide. Far too intrusive just to get a screenshot trigger.

## Notes

- Purely additive — no existing API or behavior changes.
- Documentation update (a parallel section to "Automatic screenshots with Broadcast intents" in the README) can be added either in this PR or a follow-up, whichever you prefer.

Happy to revise — particularly the action name (`TAKE_SCREENSHOT` chosen to parallel the existing `SCREENSHOT` broadcast action) or the activity name if you have a preference.
